### PR TITLE
Security hardening for ES query API and maintenance scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.12
+FROM python:3.12.7-slim
 
 #
 WORKDIR /code

--- a/app/main.py
+++ b/app/main.py
@@ -1,31 +1,99 @@
 import os
+import re
 from elasticsearch import AsyncElasticsearch, AIOHttpConnection
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import csv
 import io
-import json
 from elasticsearch.exceptions import ConnectionTimeout
 
 from .constants import DATA_PORTAL_AGGREGATIONS, ARTICLES_AGGREGATIONS
 
 app = FastAPI()
 
+# CORS: only allow explicitly configured front-end origins.
+# Set CORS_ALLOWED_ORIGINS to a comma-separated list (e.g.
+# "https://portal.example.org,https://www.example.org"). Empty by default so
+# no cross-origin access is granted unless deliberately configured. We do NOT
+# allow credentials, so a wildcard origin is never combined with cookies.
 origins = [
-    "*"
+    o.strip()
+    for o in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")
+    if o.strip()
 ]
 
 ES_HOST = os.getenv('ES_CONNECTION_URL')
 ES_USERNAME = os.getenv('ES_USERNAME')
 ES_PASSWORD = os.getenv('ES_PASSWORD')
 
+# TLS verification to Elasticsearch is enabled by default. Provide ES_CA_CERTS
+# to point at the cluster CA bundle when it is not in the system trust store.
+# ES_VERIFY_CERTS=false can disable verification for local/dev only.
+ES_VERIFY_CERTS = os.getenv('ES_VERIFY_CERTS', 'true').lower() != 'false'
+ES_CA_CERTS = os.getenv('ES_CA_CERTS') or None
+
+# Indices that may be queried through the public API. Closed allowlist by
+# default; override with the ALLOWED_INDICES env var (comma-separated) to match
+# the deployment's index names.
+ALLOWED_INDICES = {
+    i.strip()
+    for i in os.getenv(
+        'ALLOWED_INDICES',
+        'data_portal,tracking_status_index,articles,gis_filter_index',
+    ).split(',')
+    if i.strip()
+}
+
+# Bounds to prevent unbounded result windows / resource exhaustion.
+MAX_LIMIT = 1000
+MAX_SEARCH_LEN = 100
+# Hard cap on the gis_filter result set (configurable for large maps).
+GIS_MAX_RESULTS = int(os.getenv('GIS_MAX_RESULTS', '100000'))
+
+# Field/path name tokens that get interpolated into ES query DSL must be plain
+# identifiers. This prevents attacker-controlled field-name injection.
+_FIELD_TOKEN_RE = re.compile(r'^[A-Za-z0-9_]+$')
+
+
+def validate_index(index: str) -> str:
+    if index not in ALLOWED_INDICES:
+        raise HTTPException(status_code=404, detail="Unknown index")
+    return index
+
+
+def safe_field_token(value: str, what: str = "field name") -> str:
+    if not value or not _FIELD_TOKEN_RE.fullmatch(value):
+        raise HTTPException(status_code=400, detail=f"Invalid {what}")
+    return value
+
+
+def split_pair(item: str, what: str) -> tuple[str, str]:
+    """Split a 'name:value' token, returning a 400 instead of a 500 on
+    malformed input."""
+    parts = item.split(":", 1)
+    if len(parts) != 2 or not parts[0]:
+        raise HTTPException(status_code=400, detail=f"Malformed {what}")
+    return parts[0], parts[1]
+
+
+def escape_wildcard(value: str) -> str:
+    """Neutralise ES wildcard metacharacters so the user cannot inject extra
+    wildcard patterns, and cap length to limit expensive scans."""
+    value = value[:MAX_SEARCH_LEN]
+    return (
+        value.replace("\\", "\\\\")
+        .replace("*", "\\*")
+        .replace("?", "\\?")
+    )
+
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
+    allow_credentials=False,
+    allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )
 
@@ -34,14 +102,14 @@ es = AsyncElasticsearch(
     timeout=60,
     connection_class=AIOHttpConnection,
     http_auth=(ES_USERNAME, ES_PASSWORD),
-    use_ssl=True, verify_certs=False)
+    use_ssl=True, verify_certs=ES_VERIFY_CERTS, ca_certs=ES_CA_CERTS)
 
 
 @app.get("/gis_filter")
 async def get_gis_data(filter: str = None,
                        search: str = None, current_class: str = 'kingdom',
                        phylogeny_filters: str = None):
-    print(phylogeny_filters)
+    current_class = safe_field_token(current_class, "current_class")
     # data structure for ES query
     body = dict()
     # building aggregations for every request
@@ -67,9 +135,9 @@ async def get_gis_data(filter: str = None,
             }
         }
         phylogeny_filters = phylogeny_filters.split("-")
-        print(phylogeny_filters)
         for phylogeny_filter in phylogeny_filters:
-            name, value = phylogeny_filter.split(":")
+            name, value = split_pair(phylogeny_filter, "phylogeny_filters")
+            name = safe_field_token(name, "phylogeny rank")
             nested_dict = {
                 "nested": {
                     "path": f"taxonomies.{name}",
@@ -99,7 +167,7 @@ async def get_gis_data(filter: str = None,
             }
         for filter_item in filters:
             if current_class in filter_item:
-                _, value = filter_item.split(":")
+                _, value = split_pair(filter_item, "filter")
                 nested_dict = {
                     "nested": {
                         "path": f"taxonomies.{current_class}",
@@ -119,13 +187,15 @@ async def get_gis_data(filter: str = None,
                 )
                 body["query"]["bool"]["filter"].append(nested_dict)
             else:
-                filter_name, filter_value = filter_item.split(":")
+                filter_name, filter_value = split_pair(filter_item, "filter")
+                filter_name = safe_field_token(filter_name, "filter field")
                 body["query"]["bool"]["filter"].append(
                     {"term": {filter_name + '.keyword': filter_value}}
                 )
 
     # adding search string
     if search:
+        search = escape_wildcard(search)
         # body already has filter parameters
         if "query" in body:
             # body["query"]["bool"].update({"should": []})
@@ -142,9 +212,8 @@ async def get_gis_data(filter: str = None,
             {"wildcard": {"commonName.keyword": {"value": f"*{search}*",
                                                  "case_insensitive": True}}}
         )
-    print(json.dumps(body))
     response = await es.search(
-        index='gis_filter_index', body=body, size=100000,
+        index='gis_filter_index', body=body, size=GIS_MAX_RESULTS,
     )
     data = dict()
     data['count'] = response['hits']['total']['value']
@@ -158,6 +227,11 @@ async def root(index: str, offset: int = 0, limit: int = 15,
                sort: str | None = None, filter: str = None,
                search: str = None, current_class: str = 'kingdom',
                phylogeny_filters: str = None, action: str = None):
+    validate_index(index)
+    current_class = safe_field_token(current_class, "current_class")
+    # clamp paging parameters to safe bounds
+    offset = max(0, offset)
+    limit = max(1, min(limit, MAX_LIMIT))
     # data structure for ES query
     body = dict()
     # building aggregations for every request
@@ -236,9 +310,9 @@ async def root(index: str, offset: int = 0, limit: int = 15,
             }
         }
         phylogeny_filters = phylogeny_filters.split("-")
-        print(phylogeny_filters)
         for phylogeny_filter in phylogeny_filters:
-            name, value = phylogeny_filter.split(":")
+            name, value = split_pair(phylogeny_filter, "phylogeny_filters")
+            name = safe_field_token(name, "phylogeny rank")
             nested_dict = {
                 "nested": {
                     "path": f"taxonomies.{name}",
@@ -268,7 +342,7 @@ async def root(index: str, offset: int = 0, limit: int = 15,
             }
         for filter_item in filters:
             if current_class in filter_item:
-                _, value = filter_item.split(":")
+                _, value = split_pair(filter_item, "filter")
                 nested_dict = {
                     "nested": {
                         "path": f"taxonomies.{current_class}",
@@ -289,7 +363,8 @@ async def root(index: str, offset: int = 0, limit: int = 15,
                 body["query"]["bool"]["filter"].append(nested_dict)
 
             else:
-                filter_name, filter_value = filter_item.split(":")
+                filter_name, filter_value = split_pair(filter_item, "filter")
+                filter_name = safe_field_token(filter_name, "filter field")
                 if filter_name == 'experimentType':
                     nested_dict = {
                         "nested": {
@@ -317,12 +392,12 @@ async def root(index: str, offset: int = 0, limit: int = 15,
                                         'field': 'genome_notes.url'}}]}}}}
                     body["query"]["bool"]["filter"].append(nested_dict)
                 else:
-                    print(filter_name)
                     body["query"]["bool"]["filter"].append(
                         {"term": {filter_name: filter_value}})
 
     # Adding search string
     if search:
+        search = escape_wildcard(search)
         if "query" not in body:
             body["query"] = {"bool": {"must": {"bool": {"should": []}}}}
         else:
@@ -361,8 +436,6 @@ async def root(index: str, offset: int = 0, limit: int = 15,
                 }
             )
 
-    print(json.dumps(body))
-
     if action == 'download':
         try:
             response = await es.search(index=index, sort=sort, from_=offset,
@@ -384,6 +457,7 @@ async def root(index: str, offset: int = 0, limit: int = 15,
 
 @app.get("/{index}/{record_id}")
 async def details(index: str, record_id: str):
+    validate_index(index)
     body = dict()
     if 'data_portal' in index:
         body["query"] = {
@@ -458,11 +532,15 @@ async def details(index: str, record_id: str):
                                  '.organismPart.keyword',
                         'size': 2000}}
             }}
-        print(json.dumps(body))
         response = await es.search(index=index, body=body)
         aggregations = response['aggregations']
     else:
-        response = await es.search(index=index, q=f"_id:{record_id}")
+        # Use a parameterized ids query rather than the Lucene query-string
+        # interface so record_id cannot inject query operators.
+        response = await es.search(
+            index=index,
+            body={"query": {"ids": {"values": [record_id]}}},
+        )
     data = dict()
     data['count'] = response['hits']['total']['value']
     data['results'] = response['hits']['hits']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.73.0
-uvicorn==0.15.0
-elasticsearch[async]==7.17.0
-requests==2.27.1
+fastapi==0.115.6
+uvicorn==0.32.1
+elasticsearch[async]==7.17.12
+requests==2.32.3

--- a/scripts/update_symbionts_status.py
+++ b/scripts/update_symbionts_status.py
@@ -1,21 +1,24 @@
-import urllib3
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import warnings
-
-warnings.filterwarnings('ignore', message='Unverified HTTPS request')
-warnings.filterwarnings("ignore")
+import os
 
 from elasticsearch import Elasticsearch
 from elasticsearch import RequestsHttpConnection
 
+ES_HOST = os.environ['ES_CONNECTION_URL']
+ES_USERNAME = os.environ['ES_USERNAME']
+ES_PASSWORD = os.environ['ES_PASSWORD']
+ES_VERIFY_CERTS = os.getenv('ES_VERIFY_CERTS', 'true').lower() != 'false'
+ES_CA_CERTS = os.getenv('ES_CA_CERTS') or None
+
+
+def get_es_client():
+    return Elasticsearch(
+        [ES_HOST], connection_class=RequestsHttpConnection,
+        http_auth=(ES_USERNAME, ES_PASSWORD),
+        use_ssl=True, verify_certs=ES_VERIFY_CERTS, ca_certs=ES_CA_CERTS)
 
 
 def update_symbionts_status():
-    es = Elasticsearch(
-        ['es_host'], connection_class=RequestsHttpConnection,
-        http_auth=('username', 'password'),
-        use_ssl=True, verify_certs=False)
+    es = get_es_client()
 
     data = es.search(index='data_portal', size=10000, from_=0, track_total_hits=True)
 
@@ -40,10 +43,7 @@ def update_symbionts_status():
 
 
 def update_metagenomes_status():
-    es = Elasticsearch(
-        ['es_host'], connection_class=RequestsHttpConnection,
-        http_auth=('username', 'password'),
-        use_ssl=True, verify_certs=False)
+    es = get_es_client()
 
     data = es.search(index='data_portal', size=10000, from_=0, track_total_hits=True)
 

--- a/scripts/update_tracking_status_index.py
+++ b/scripts/update_tracking_status_index.py
@@ -1,18 +1,24 @@
-import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import warnings
-warnings.filterwarnings('ignore', message='Unverified HTTPS request')
-warnings.filterwarnings("ignore")
+import os
 
 from elasticsearch import Elasticsearch
 from elasticsearch import RequestsHttpConnection
 
+ES_HOST = os.environ['ES_CONNECTION_URL']
+ES_USERNAME = os.environ['ES_USERNAME']
+ES_PASSWORD = os.environ['ES_PASSWORD']
+ES_VERIFY_CERTS = os.getenv('ES_VERIFY_CERTS', 'true').lower() != 'false'
+ES_CA_CERTS = os.getenv('ES_CA_CERTS') or None
+
+
+def get_es_client():
+    return Elasticsearch(
+        [ES_HOST], connection_class=RequestsHttpConnection,
+        http_auth=(ES_USERNAME, ES_PASSWORD),
+        use_ssl=True, verify_certs=ES_VERIFY_CERTS, ca_certs=ES_CA_CERTS)
+
 
 def update_tracking_status_symbionts():
-    es = Elasticsearch(
-        ['es_host'], connection_class=RequestsHttpConnection,
-        http_auth=('username', 'password'),
-        use_ssl=True, verify_certs=False)
+    es = get_es_client()
 
     data = es.search(index='data_portal', size=10000, from_=0, track_total_hits=True)
 
@@ -39,10 +45,7 @@ def update_tracking_status_symbionts():
 
 
 def update_tracking_status_metagenomes():
-    es = Elasticsearch(
-        ['es_host'], connection_class=RequestsHttpConnection,
-        http_auth=('username', 'password'),
-        use_ssl=True, verify_certs=False)
+    es = get_es_client()
 
     data = es.search(index='data_portal', size=10000, from_=0, track_total_hits=True)
 


### PR DESCRIPTION
- Enforce a closed index allowlist (env-configurable) on /{index} and /{index}/{record_id} to stop arbitrary Elasticsearch index access
- Replace Lucene query-string lookup (q=_id:...) with a parameterized ids query to prevent query injection via record_id
- Validate user-supplied field/path tokens and split "name:value" filters safely to block field-name injection and avoid 500s on malformed input
- Enable TLS certificate verification to Elasticsearch (configurable via ES_VERIFY_CERTS / ES_CA_CERTS) in the API and both maintenance scripts; move scripts off hardcoded placeholder credentials to env vars
- Tighten CORS: configurable origins, disable credentials, restrict methods
- Clamp limit/offset, cap search length and escape wildcard metacharacters
- Remove debug logging of raw query bodies
- Upgrade dependencies (fastapi, uvicorn, requests, elasticsearch client) and bump Docker base image to python:3.12.7-slim