### PR TITLE
Add tracking_status to default index allowlist

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,7 +41,8 @@ ALLOWED_INDICES = {
     i.strip()
     for i in os.getenv(
         'ALLOWED_INDICES',
-        'data_portal,tracking_status_index,articles,gis_filter_index',
+        'data_portal,tracking_status,tracking_status_index,'
+        'articles,gis_filter_index',
     ).split(',')
     if i.strip()
 }


### PR DESCRIPTION
The API exposes the index under the name "tracking_status" (the code branches on the substring), so the closed allowlist must include it alongside the script-side "tracking_status_index". Without it, valid requests to /tracking_status returned 404 "Unknown index".